### PR TITLE
Fix: Force 'eager' attention for Wav2Vec2 to resolve SDPA conflict

### DIFF
--- a/models/float/FLOAT.py
+++ b/models/float/FLOAT.py
@@ -209,7 +209,7 @@ class AudioEncoder(BaseModel):
 		self.num_frames_for_clip = int(opt.wav2vec_sec * self.opt.fps)
 		self.num_prev_frames = int(opt.num_prev_frames)
 
-		self.wav2vec2 = Wav2VecModel.from_pretrained(opt.wav2vec_model_path, local_files_only = True)
+		self.wav2vec2 = Wav2VecModel.from_pretrained(opt.wav2vec_model_path, local_files_only=True, attn_implementation="eager")
 		self.wav2vec2.feature_extractor._freeze_parameters()
 
 		for name, param in self.wav2vec2.named_parameters():

--- a/models/wav2vec2.py
+++ b/models/wav2vec2.py
@@ -51,8 +51,10 @@ class Wav2VecModel(Wav2Vec2Model):
         Returns:
             The output of the Wav2Vec model.
         """
-        self.config.output_attentions = True
+        self.config.output_attentions = True # Reverted: Force output_attentions to True
 
+        # output_attentions argument from the caller is now ignored for the encoder call.
+        # output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         )
@@ -76,7 +78,7 @@ class Wav2VecModel(Wav2Vec2Model):
         encoder_outputs = self.encoder(
             hidden_states,
             attention_mask=attention_mask,
-            output_attentions=output_attentions,
+            output_attentions=self.config.output_attentions, # Ensure True is effectively passed
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
         )
@@ -138,8 +140,10 @@ class Wav2VecModel(Wav2Vec2Model):
         Returns:
             The encoded output features.
         """
-        self.config.output_attentions = True
+        self.config.output_attentions = True # Reverted: Force output_attentions to True
 
+        # output_attentions argument from the caller is now ignored for the encoder call.
+        # output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         )
@@ -159,7 +163,7 @@ class Wav2VecModel(Wav2Vec2Model):
         encoder_outputs = self.encoder(
             hidden_states,
             attention_mask=attention_mask,
-            output_attentions=output_attentions,
+            output_attentions=self.config.output_attentions, # Ensure True is effectively passed
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
         )


### PR DESCRIPTION
This commit resolves a `ValueError` related to `output_attentions` being incompatible with the "sdpa" attention implementation in the Hugging Face Wav2Vec2 model.

The chosen solution is to force the use of the "eager" attention mechanism, which supports `output_attentions=True`.

Changes:
1.  **`models/float/FLOAT.py` (`AudioEncoder.__init__`):**
    - I modified the `Wav2VecModel.from_pretrained(...)` call to include the `attn_implementation="eager"` argument. This ensures the Wav2Vec2 model is loaded with an attention mechanism that is compatible with outputting attention weights.

2.  **`models/wav2vec2.py` (`Wav2VecModel`):**
    - I ensured that `self.config.output_attentions = True` is set within the `forward` and `encode` methods.
    - The call to the underlying encoder now explicitly requests attention outputs, relying on the "eager" implementation to provide them without error.

This approach allows the model to continue requesting attention outputs if they are needed, by using an attention implementation that supports this feature.